### PR TITLE
Added requirement of Node 16 for Husky to readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ It is recommended to use several tools:
 - Visual Studio Code
 - Git Graph VSCode extension
 - installed git command 😅
+- installed Node version of at least 16 because of Husky
 
 ## Git commands
 


### PR DESCRIPTION
#### Decription
Added hint to the requirements to install Node 16, because under that included Husky hooks fail